### PR TITLE
expose embedAs object key for twitter video embeds

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,10 @@ function renderSpotify ({url, height}) {
 const embeds = {
   youtube: ({youtubeId}) => render({type: 'youtube', youtubeId}),
   image: ({src}) => render({type: 'image', src}),
-  twitter: ({text, url, date, user, id}) => (<iframe>
+  twitter: ({embedAs, text, url, date, user, id}) => (<iframe>
     {render({
       type: 'twitter',
-      text, url, date, user, id
+      embedAs, text, url, date, user, id
     })}
     <script async='true' src='//platform.twitter.com/widgets.js' charset='utf-8'></script>
   </iframe>),

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "article-json-html-render": "^1.2.0",
     "deku": "^2.0.0-rc16",
-    "embeds": "^2.4.0",
+    "embeds": "^2.5.0",
     "object-assign": "^4.0.1",
     "url-join": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "article-json-html-render": "^1.2.0",
     "deku": "^2.0.0-rc16",
-    "embeds": "^1.4.2",
+    "embeds": "^2.4.0",
     "object-assign": "^4.0.1",
     "url-join": "^1.1.0"
   }

--- a/test.js
+++ b/test.js
@@ -151,6 +151,7 @@ test('twitter', t => {
   const input = [{
     type: 'embed',
     embedType: 'twitter',
+    embedAs: 'tweet',
     text: [
       {content: 'GIF vs. JIF… This ', href: null},
       {content: 'pic.twitter.com/qFAHWgdbL6', href: 'https://t.co/qFAHWgdbL6'}
@@ -168,7 +169,7 @@ test('twitter', t => {
     <article>
       <figure class="op-social">
         <iframe>
-          <blockquote class="twitter-tweet" lang="en">
+          <blockquote class="twitter-tweet" data-lang="en">
             <p lang="en" dir="ltr">GIF vs. JIF… This <a href="https://t.co/qFAHWgdbL6">pic.twitter.com/qFAHWgdbL6</a></p>&mdash; Matt (foo) Navarra (@MattNavarra) <a href="https://twitter.com/MattNavarra/status/684690494841028608">January 6, 2016</a>
           </blockquote>
           <script async="true" src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
referenced micnews/embeds#24 - expose embedAs object key for twitter video embeds.

Depends on [PR#30](https://github.com/micnews/embeds/pull/30)
