### PR TITLE
Add support for Tumblr post embeds

### DIFF
--- a/lib/format-items.js
+++ b/lib/format-items.js
@@ -33,6 +33,11 @@ const embedTypes = {
     figureProps: {
       'class': 'op-social'
     }
+  }),
+  tumblr: () => ({
+    figureProps: {
+      'class': 'op-interactive'
+    }
   })
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,13 @@ const embeds = {
 
   spotify: renderSpotify,
 
+  tumblr: ({did, url, text}) => (
+    <iframe>
+      {render({type: 'tumblr', did, url, text})}
+      <script async src='https://secure.assets.tumblr.com/post.js'></script>
+    </iframe>
+  ),
+
   // custom needs to be last
   custom: ({src, width, height, secure}) => secure && render({type: 'custom', src, width, height}) || ''
 };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "article-json-html-render": "^2.0.0",
     "deku": "^1.0.0",
-    "embeds": "^2.5.0",
+    "embeds": "^2.6.0",
     "magic-virtual-element": "^1.0.6",
     "object-assign": "^4.0.1",
     "url-join": "^1.1.0"

--- a/test.js
+++ b/test.js
@@ -301,6 +301,38 @@ test('blockquote', t => {
   t.is(actual, expected);
 });
 
+test('tumblr embed', t => {
+  const data = [{
+    caption: [],
+    type: 'embed',
+    embedType: 'tumblr',
+    did: '7c08ba46cb75162284770cdee2a59365891a5e18',
+    url: 'https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392',
+    text: [{
+      content: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento',
+      href: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento'
+    }]
+  }];
+
+  const actual = toFbia(data);
+  const expected = tsml`
+    <article>
+      <figure class="op-interactive">
+        <iframe>
+          <div class="tumblr-post" data-href="https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392" data-did="7c08ba46cb75162284770cdee2a59365891a5e18">
+            <a href="http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento">
+              http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento
+            </a>
+          </div>
+          <script async="true" src="https://secure.assets.tumblr.com/post.js"></script>
+        </iframe>
+      </figure>
+    </article>
+  `;
+
+  t.is(actual, expected);
+});
+
 test('custom secure iframe', t => {
   const data = [{
     type: 'embed',


### PR DESCRIPTION
This adds support for tumblr posts.

This relies on the following micnews/embeds and micnews/html-to-article-json PR's.

https://github.com/micnews/html-to-article-json/pull/67
https://github.com/micnews/embeds/pull/39
